### PR TITLE
bumped to 1.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "type": "git",
     "url": "https://github.com/Se7enSky/group-css-media-queries.git"
   },
-  "version": "1.1.0",
+  "version": "1.1.1",
   "main": "index",
   "bin": {
     "group-css-media-queries": "./bin/group-css-media-queries"


### PR DESCRIPTION
Just need this to publish to npm.  For whatever reason the 1.1.0 release did not have the update to line 37 in `index.js`