### PR TITLE
fix for use of interface in css 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "group-css-media-queries": "./bin/group-css-media-queries"
   },
   "dependencies": {
-    "css-parse": "*",
-    "css-stringify": "*"
+    "css-parse": "^2.0.0",
+    "css-stringify": "^2.0.0"
   },
   "engines": {
     "node": ">=0.8.0"


### PR DESCRIPTION
Version 2 of CSS is required to have the interface needed to filter AST on media types.